### PR TITLE
Fix job pipeline status typing

### DIFF
--- a/components/dashboard/job-pipeline.tsx
+++ b/components/dashboard/job-pipeline.tsx
@@ -41,7 +41,7 @@ const PIPELINE_STATUSES = [
   { id: "offered", color: "bg-green-400" },
 ] as const
 
-const VALID_STATUSES = new Set(PIPELINE_STATUSES.map(s => s.id))
+const VALID_STATUSES = new Set<string>(PIPELINE_STATUSES.map((status) => status.id))
 
 const statusLabels: Record<string, string> = {
   saved: "Saved",


### PR DESCRIPTION
### Motivation
- The Next.js production build failed due to a TypeScript error where `job.status` (a `string`) was being checked against a `Set` typed to a narrower union of literal status ids.
- The `Set.has()` parameter was inferred as the union literal type from `PIPELINE_STATUSES`, causing `Argument of type 'string' is not assignable to parameter of type '...'.`
- Widening the `Set` element type to `string` ensures runtime checks like `VALID_STATUSES.has(job.status)` accept the `string`-typed `job.status` without a type error.

### Description
- Update `components/dashboard/job-pipeline.tsx` to declare `VALID_STATUSES` as `new Set<string>(...)` instead of inferring the literal union.
- This change makes the `Set.has(...)` call accept a `string` and removes the TypeScript build error related to job status checks.

### Testing
- Ran `npm run test` (Vitest) and all tests passed (122 tests across 14 files).
- Ran `npm run build` and the Next.js production build compiled successfully.
- No additional code changes were required after the typing update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c294c834083298d7d05246a5b8084)